### PR TITLE
yamllintの導入

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -14,17 +14,13 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout"
+      - name: "checkout"
         uses: actions/checkout@v4
-      - name: "Create PR comment of reviewdog"
+
+      - name: "review yaml file format"
         uses: reviewdog/action-yamllint@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           level: warning
           yamllint_flags: '-c .yamllint ./.github/workflows/'
-      - name: "lint All The Things in Repository"
-        uses: karancode/yamllint-github-action@v2.1.1
-        with:
-          yamllint_file_or_dir: ./.github/workflows/
-          yamllint_config_filepath: .yamllint

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -23,3 +23,4 @@ jobs:
           reporter: "github-pr-review"
           level: "warning"
           yamllint_flags: '-c .yamllint ./.github/workflows/'
+          fail_on_error: true

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -2,25 +2,24 @@
 # 
 # GitHubActionsのCI/CDにyamllintを組み込んで作業の安全性を高める
 # https://qiita.com/EnKUMA/items/6974e310221fc9765c2f
-name: yamllint
+name: "yamllint"
 
 on:
   pull_request:
     branches:
       - "main"
-    types: [opened, synchronize, closed]
+    types: [ "opened", "synchronize", "closed" ]
 
 jobs:
   yamllint:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-latest"
     steps:
       - name: "checkout"
-        uses: actions/checkout@v4
-
+        uses: "actions/checkout@v4"
       - name: "review yaml file format"
-        uses: reviewdog/action-yamllint@v1
+        uses: "reviewdog/action-yamllint@v1"
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
-          level: warning
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          reporter: "github-pr-review"
+          level: "warning"
           yamllint_flags: '-c .yamllint ./.github/workflows/'

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,29 @@
+# @EnKUMAによる以下の記事を参考に作成
+# 
+# GitHubActionsのCI/CDにyamllintを組み込んで作業の安全性を高める
+# https://qiita.com/EnKUMA/items/6974e310221fc9765c2f
+name: yamllint
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    types: [opened, synchronize, closed]
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: "Create PR comment of reviewdog"
+        uses: reviewdog/action-yamllint@v1
+        with:
+          reporter: github-pr-review
+          level: warning
+          yamllint_flags: '-c .yamllint ./.github/workflows/'
+      - name: "lint All The Things in Repository"
+        uses: karancode/yamllint-github-action@v2.1.1
+        with:
+          yamllint_file_or_dir: ./.github/workflows/
+          yamllint_config_filepath: .yamllint

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: "checkout"
         uses: "actions/checkout@v4"
-      - name: "review yaml file format"
+      - name: "review yaml format"
         uses: "reviewdog/action-yamllint@v1"
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -19,6 +19,7 @@ jobs:
       - name: "Create PR comment of reviewdog"
         uses: reviewdog/action-yamllint@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           level: warning
           yamllint_flags: '-c .yamllint ./.github/workflows/'

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -22,5 +22,5 @@ jobs:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           reporter: "github-pr-review"
           level: "warning"
-          yamllint_flags: '-c .yamllint ./.github/workflows/'
+          yamllint_flags: "-c .yamllint ./.github/workflows/"
           fail_on_error: true

--- a/.yamllint
+++ b/.yamllint
@@ -35,7 +35,7 @@ rules:
     level: warning
   new-lines: enable
   octal-values: disable
-  quoted-strings: enable
+  quoted-strings:
     quote-type: double
   trailing-spaces: disable
   truthy: disable

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,41 @@
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+rules:
+  braces:
+    level: warning
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
+  comments:
+    level: warning
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  empty-lines: disable
+  empty-values: disable
+  hyphens: disable
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file:
+    level: warning
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: enable
+  trailing-spaces: disable
+    level: warning
+  truthy: disable

--- a/.yamllint
+++ b/.yamllint
@@ -36,5 +36,6 @@ rules:
   new-lines: enable
   octal-values: disable
   quoted-strings: enable
+    quote-type: double
   trailing-spaces: disable
   truthy: disable

--- a/.yamllint
+++ b/.yamllint
@@ -37,5 +37,4 @@ rules:
   octal-values: disable
   quoted-strings: enable
   trailing-spaces: disable
-    level: warning
   truthy: disable

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Android GitHub Actions Playground
 
 Androidアプリ開発に関するGitHub Actionsの実験場
+
+## ワークフローの説明
+
+### yamllint
+
+[adrienverge/yamllint: A linter for YAML files.](https://github.com/adrienverge/yamllint)、および[reviewdog/action-yamllint: Run yamllint with reviewdog](https://github.com/reviewdog/action-yamllint)を用いた、YAMLファイルのlintを実行するワークフロー。
+
+YAMLのフォーマットは `.yamllint` に定義する。


### PR DESCRIPTION
[GitHubActionsのCI/CDにyamllintを組み込んで作業の安全性を高める #YAML - Qiita](https://qiita.com/EnKUMA/items/6974e310221fc9765c2f)を参考に、yamllintを導入。

- [adrienverge/yamllint: A linter for YAML files.](https://github.com/adrienverge/yamllint)
- [karancode/yamllint-github-action: Github Action for linting yaml files using yamllint](https://github.com/karancode/yamllint-github-action)
- [reviewdog/action-yamllint: Run yamllint with reviewdog](https://github.com/reviewdog/action-yamllint)