### PR TITLE
.yamllintの不要な設定の削除

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,7 +1,6 @@
 yaml-files:
   - '*.yaml'
   - '*.yml'
-  - '.yamllint'
 
 rules:
   braces:


### PR DESCRIPTION
現状、CIでは `.github/workflows/*` しかlintをかけてないことを踏まえて、不要な設定を削除する。