### PR TITLE
.yamllintへのリンクを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Androidアプリ開発に関するGitHub Actionsの実験場
 
 [adrienverge/yamllint: A linter for YAML files.](https://github.com/adrienverge/yamllint)、および[reviewdog/action-yamllint: Run yamllint with reviewdog](https://github.com/reviewdog/action-yamllint)を用いた、YAMLファイルのlintを実行するワークフロー。
 
-YAMLのフォーマットは[.yamllint](./yamllint)に定義する。
+YAMLのフォーマットは[.yamllint](./.yamllint)に定義する。
 
 ### actionlint
 


### PR DESCRIPTION
READMEから `.yamlllint` へのリンクが正しくなかったため、修正する。