### PR TITLE
danger-actionの代わりにbundle exec dangerを実行する

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -17,11 +17,7 @@ jobs:
         with:
           bundler-cache: true
       - name: "run danger"
-        uses: "MeilCli/danger-action@v6"
-        with:
-          danger_file: "Dangerfile"
-          danger_id: "danger-pr"
-          install_path: "vendor/bundle"
-          plugins_file: "Gemfile"
+        run: |
+          danger
         env:
           DANGER_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -18,6 +18,6 @@ jobs:
           bundler-cache: true
       - name: "run danger"
         run: |
-          danger
+          bundle exec danger
         env:
           DANGER_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
DangerをMeilCli/danger-action経由で実行していたが、不要であるため削除する。
bundlerのキャッシュを有効にしているため、bundle installは不要で、bundle execのみ実行すれば良い。